### PR TITLE
fix: accept QIR runtime read result calls

### DIFF
--- a/quantinuum_qircheck/qircheck.py
+++ b/quantinuum_qircheck/qircheck.py
@@ -263,7 +263,6 @@ def is_valid_quantum_call(instr: pq.Call) -> bool:
         "__quantum__qis__h__body",
         "__quantum__qis__y__body",
         "__quantum__qis__anynonzero__body",
-        "__quantum__qis__read_result__body",
         "__quantum__qis__cnot__body",
         "__quantum__qis__cz__body",
         "__quantum__qis__x__body",
@@ -303,8 +302,11 @@ def is_valid_quantum_call(instr: pq.Call) -> bool:
 
 
 def is_valid_classical_call(instr: pq.Call) -> bool:
-    """Determines whether a gate application has a valid form"""
+    """Determines whether a classical QIR function call has a valid form"""
     classical_instr_set = {
+        "__quantum__rt__read_result",
+        "__quantum__qis__read_result__body",  # legacy name of the above
+        "__quantum__rt__initialize",
         "___get_current_shot",
         "___set_random_index",
         "___random_int",

--- a/tests/check_test.py
+++ b/tests/check_test.py
@@ -39,8 +39,34 @@ def test_check_qir_invalid_fileset() -> None:
             with pytest.raises(ValueError) as e:
                 qc.qircheck(qir_str)
 
-            if file == "invalid_1.ll":
+            if file.name == "invalid_1.ll":
                 assert "Qqis" in str(e)
 
-            if file == "invalid_2.ll":
+            if file.name == "invalid_2.ll":
                 assert "Found loop in CFG" in str(e)
+
+
+def test_unknown_runtime_call_is_rejected() -> None:
+    qir = """
+%Qubit = type opaque
+%Result = type opaque
+
+define void @main() #0 {
+entry:
+  call void @__quantum__rt__unknown()
+  ret void
+}
+
+declare void @__quantum__rt__unknown()
+
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+"""
+    with pytest.raises(ValueError):
+        qc.qircheck(qir)

--- a/tests/qir/valid/qir-1-adaptive-runtime-calls.ll
+++ b/tests/qir/valid/qir-1-adaptive-runtime-calls.ll
@@ -1,0 +1,38 @@
+; ModuleID = 'qir_1_adaptive_runtime_calls'
+source_filename = "qir_1_adaptive_runtime_calls"
+
+%Qubit = type opaque
+%Result = type opaque
+
+define void @main() #0 {
+entry:
+  call void @__quantum__rt__initialize(i8* null)
+  call void @__quantum__qis__mz__body(%Qubit* null, %Result* writeonly null)
+  %0 = call i1 @__quantum__rt__read_result(%Result* readonly null)
+  br i1 %0, label %then, label %continue
+
+then:
+  call void @__quantum__qis__x__body(%Qubit* null)
+  br label %continue
+
+continue:
+  ret void
+}
+
+declare void @__quantum__rt__initialize(i8*)
+
+declare i1 @__quantum__rt__read_result(%Result* readonly)
+
+declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+
+declare void @__quantum__qis__x__body(%Qubit*)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+attributes #1 = { "irreversible" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}

--- a/tests/qir/valid/qir-2-adaptive-runtime-calls.ll
+++ b/tests/qir/valid/qir-2-adaptive-runtime-calls.ll
@@ -1,0 +1,35 @@
+; ModuleID = 'qir_2_adaptive_runtime_calls'
+source_filename = "qir_2_adaptive_runtime_calls"
+
+define void @main() #0 {
+entry:
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr writeonly null)
+  %0 = call i1 @__quantum__rt__read_result(ptr readonly null)
+  br i1 %0, label %then, label %continue
+
+then:
+  call void @__quantum__qis__x__body(ptr null)
+  br label %continue
+
+continue:
+  ret void
+}
+
+declare void @__quantum__rt__initialize(ptr)
+
+declare i1 @__quantum__rt__read_result(ptr readonly)
+
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
+
+declare void @__quantum__qis__x__body(ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+attributes #1 = { "irreversible" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"qir_major_version", i32 2}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}


### PR DESCRIPTION
## Summary
- accept the QIR 1.0/2.0 `__quantum__rt__read_result` spelling through the classical-call validation path
- accept `__quantum__rt__initialize` in the same path
- keep legacy `__quantum__qis__read_result__body` accepted for backwards compatibility

## Validation
- `uv run --extra test pytest tests/check_test.py -q`
- `uv run pre-commit run --files quantinuum_qircheck/qircheck.py tests/check_test.py tests/qir/valid/qir-1-adaptive-runtime-calls.ll tests/qir/valid/qir-2-adaptive-runtime-calls.ll`
- `uv run --extra test --with mypy ./mypy-check quantinuum_qircheck`
- `git diff --check`