### PR TITLE
fix: publish the canonical release wheel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.wasm binary

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         ./.github/workflows/build-test nomypy
     - uses: actions/upload-artifact@v7
-      if: github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')) && matrix.os == 'ubuntu-latest'
       with:
         name: artefact-${{ matrix.os }}
         path: wheelhouse/

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -81,22 +81,20 @@ jobs:
     needs: qir-checks
     runs-on: ubuntu-latest
     steps:
-    - name: Download all wheels
-      # downloading all three files into the wheelhouse
-      # all files are identical, so there will only be one file
+    - name: Download release wheel
+      # This is currently a pure Python wheel, so publish the Ubuntu artifact
+      # instead of merging same-named matrix outputs.
       uses: actions/download-artifact@v8
       with:
         path: wheelhouse
-        pattern: artefact-*
-        merge-multiple: true
-    - name: Put them all in the dist folder
+        name: artefact-ubuntu-latest
+    - name: Put wheel in the dist folder
       run: |
         mkdir dist
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do cp $w dist/ ; done
+        cp wheelhouse/*.whl dist/
     - name: Publish wheels
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_QIRCHECK_API_TOKEN }}
         verbose: true
-


### PR DESCRIPTION
## Summary

- publish PyPI releases from the Ubuntu wheel artifact instead of merging all matrix artifacts
- add `.gitattributes` so text files check out with LF line endings and `*.wasm` stays binary
- document the release job invariant near the artifact download step

## Details

The v0.6.0 release job downloaded all three OS wheel artifacts into the same `wheelhouse` directory with `merge-multiple: true`. All matrix jobs produce the same `quantinuum_qircheck-0.6.0-py3-none-any.whl` filename, but the Windows-built wheel differs because its checkout uses CRLF line endings in packaged text files.

The previous v0.5.0 release also had a different Windows artifact, but the file uploaded to PyPI matched the Ubuntu artifact. In v0.6.0, the upload candidate hash did not match any clean artifact, and PyPI rejected it as an invalid distribution.

Because this project currently builds a pure Python wheel, the release job now uses `artefact-ubuntu-latest` as the canonical PyPI distribution and avoids merging same-named matrix outputs.

## Testing

- `git diff --check -- .github/workflows/build_and_test.yml .gitattributes`