### PR TITLE
Annotate invalid examples with explanation of the errors

### DIFF
--- a/tests/qir/invalid/Q2test_bitreg_as_bit_1-QIRProfile.ADAPTIVE.ll
+++ b/tests/qir/invalid/Q2test_bitreg_as_bit_1-QIRProfile.ADAPTIVE.ll
@@ -1,3 +1,4 @@
+; Error: Duplicate record output calls are not allowed. In this case, the same module global is used twice.
 ; ModuleID = 'test_bitreg_as_bit_1'
 source_filename = "test_bitreg_as_bit_1"
 

--- a/tests/qir/invalid/Q2test_bitreg_as_bit_1-QIRProfile.ADAPTIVE2.ll
+++ b/tests/qir/invalid/Q2test_bitreg_as_bit_1-QIRProfile.ADAPTIVE2.ll
@@ -1,3 +1,4 @@
+; Error: Duplicate record output calls are not allowed. In this case, the output names are duplicated, causing the error.
 ; ModuleID = 'test_bitreg_as_bit_1'
 source_filename = "test_bitreg_as_bit_1"
 

--- a/tests/qir/invalid/g2.ll
+++ b/tests/qir/invalid/g2.ll
@@ -1,3 +1,4 @@
+; Error:  Unsupported Instruction  '%.mux = select i1 %Pivot10918, ptr inttoptr (i64 5 to ptr), ptr inttoptr (i64 6 to ptr)'. Qubit* SSA vars are not supported.
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"

--- a/tests/qir/invalid/g3.ll
+++ b/tests/qir/invalid/g3.ll
@@ -1,3 +1,4 @@
+; Error: Invalid Instruction '%qu = phi ptr [ inttoptr (i64 4 to ptr), %alloca_block ]'. Qubit* SSA vars are not supported.
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"

--- a/tests/qir/invalid/invalid_1.ll
+++ b/tests/qir/invalid/invalid_1.ll
@@ -1,3 +1,4 @@
+; Error: Attempts to call function '@__quantum__Qqis__h__body', which is not defined (typo of `__quantum__qis__h__body`)
 ; ModuleID = 'test_pytket_qir'
 source_filename = "test_pytket_qir"
 

--- a/tests/qir/invalid/invalid_2.ll
+++ b/tests/qir/invalid/invalid_2.ll
@@ -1,3 +1,4 @@
+; Error: Contains a loop, which is unsupported. Block cond_104_case_0 can branch backwards to block cond_exit_176.
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"


### PR DESCRIPTION
# Description

Adds an `; Error` comment explaining the expected error to the beginning of each invalid qir example.


# Related issues


# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
