### PR TITLE
fix: avoid repeated setup-uv hooks in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,14 +30,13 @@ jobs:
         fetch-depth: '0'
         submodules: true
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v8.1.0
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/setup-python@v6
       with:
         python-version: '3.10'
-    - name: Set up uv
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      uses: astral-sh/setup-uv@v8.1.0
     - name: Build and test (3.10)
       if: github.event_name == 'push' || github.event_name == 'schedule'
       shell: bash
@@ -47,8 +46,6 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
-    - name: Set up uv
-      uses: astral-sh/setup-uv@v8.1.0
     - name: Build and test including remote checks (3.11)
       if:  (matrix.os == 'macos-latest') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
       shell: bash
@@ -68,9 +65,6 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
-    - name: Set up uv
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
-      uses: astral-sh/setup-uv@v8.1.0
     - name: Build and test (3.12)
       if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       shell: bash


### PR DESCRIPTION
## Summary
- move `astral-sh/setup-uv` to a single job-level step in `build_and_test.yml`
- remove the repeated per-Python `setup-uv` invocations added in #31

## Testing
- inspected failing `main` Actions run `26231210114` and confirmed all build and test steps passed before the Windows `Post Set up uv` cleanup failed

## Notes
- this is a narrow follow-up to the PR #31 merge failure on `main` and only changes workflow setup/cleanup behavior